### PR TITLE
fix for PDE_DATA not defined

### DIFF
--- a/misc-modules/jit.c
+++ b/misc-modules/jit.c
@@ -93,7 +93,11 @@ int jit_fn_show(struct seq_file *m, void *v)
 
 static int jit_fn_open(struct inode *inode, struct file *file)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
 	return single_open(file, jit_fn_show, PDE_DATA(inode));
+#else
+	return single_open(file, jit_fn_show, pde_data(inode));
+#endif
 }
 
 static const struct file_operations jit_fn_fops = {
@@ -303,7 +307,11 @@ int jit_tasklet_show(struct seq_file *m, void *v)
 
 static int jit_tasklet_open(struct inode *inode, struct file *file)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,17,0)
 	return single_open(file, jit_tasklet_show, PDE_DATA(inode));
+#else
+	return single_open(file, jit_tasklet_show, pde_data(inode));
+#endif
 }
 
 static const struct file_operations jit_tasklet_fops = {


### PR DESCRIPTION
`PDE_DATA` became `pde_data` in Kernel 5.17+, and buildroot is currently on 6.x kernel, so wrap it with ifdefs as seen in [this patch](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=1ab7a6af57556b2c20749d363d1980cf47458be3).